### PR TITLE
添加luapath到配置文件中

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -361,6 +361,31 @@ function setcookie(name, value, expire, path, domain, secure, httponly)
     header(cookie)
 end
 
+function jsonrpc_handle(data, apis)
+    header('Content-Type:text/javascript')
+    if data and data.method then
+        local v = '1.0'
+        if data.method:find('.', 1, true) then
+            v = '2.0'
+        end
+        if not data.jsonrpc then data.jsonrpc = v end
+        local method = explode(data.method, '.')
+        if apis[method[1]] and (v == '1.0' or apis[method[1]][method[2]]) then
+            print(json_encode(
+                    {
+                    jsonrpc = data.jsonrpc,
+                    result = (v == '1.0' and apis[method[1]] or apis[method[1]][method[2]])(unpack(data.params)),
+                    error = null
+                    }
+                ))
+        else
+            print(json_encode({jsonrpc = data.jsonrpc,result = null,error = "method not exists!"}))
+        end
+    else
+        print(json_encode({jsonrpc = v,result = null,error = "Agreement Error!"}))
+    end
+end
+
 _loadstring = loadstring
 function loadstring(s,c)
     local f,e = _loadstring(s,c)

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,7 @@ logf_t *ACCESS_LOG = NULL;
 static char tbuf_4096[4096] = {0};
 
 extern int code_cache_ttl;
+extern char process_chdir[924];
 
 static void on_master_exit_handler()
 {
@@ -201,7 +202,7 @@ int main(int argc, const char **argv)
     lua_pop(_L, 1);
 
     sprintf(tbuf_4096,
-            "package.path = '%s/lua-libs/?.lua;' .. package.path package.cpath = '%s/lua-libs/?.so;' .. package.cpath", cwd, cwd);
+            "package.path = '%slua-libs/?.lua;' .. package.path package.cpath = '%slua-libs/?.so;' .. package.cpath", cwd, cwd);
     luaL_dostring(_L, tbuf_4096);
 
     luaL_dostring(_L, ""

--- a/src/network.c
+++ b/src/network.c
@@ -5,6 +5,7 @@
 #include "worker.h"
 #include "cached-ntoa.h"
 
+#define BUFFER_SIZE 4096
 static char temp_buf[8192];
 static char temp_buf64k[61440];
 
@@ -809,7 +810,7 @@ int network_be_read(se_ptr_t *ptr)
     update_timeout(epd->timeout_ptr, STEP_READ_TIMEOUT);
 
     if(epd->headers == NULL) {
-        epd->headers = malloc(4096);
+        epd->headers = malloc(BUFFER_SIZE);
 
         if(epd->headers == NULL) {
             LOGF(ERR, "malloc error");
@@ -817,12 +818,12 @@ int network_be_read(se_ptr_t *ptr)
             return 0;
         }
 
-        epd->buf_size = 4096;
+        epd->buf_size = BUFFER_SIZE;
         epd->start_time = longtime();
 
     } else if(epd->data_len == epd->buf_size) {
         {
-            char *_t = (char *) realloc(epd->headers, epd->buf_size + 4096);
+            char *_t = (char *) realloc(epd->headers, epd->buf_size + BUFFER_SIZE);
 
             if(_t != NULL) {
                 epd->headers = _t;
@@ -833,7 +834,7 @@ int network_be_read(se_ptr_t *ptr)
                 return 0;
             }
 
-            epd->buf_size += 4096;
+            epd->buf_size += BUFFER_SIZE;
         }
     }
 
@@ -856,7 +857,7 @@ int network_be_read(se_ptr_t *ptr)
         }
 
         if(epd->data_len + n >= epd->buf_size) {
-            char *_t = (char *) realloc(epd->headers, epd->buf_size + 4096);
+            char *_t = (char *) realloc(epd->headers, epd->buf_size + BUFFER_SIZE);
 
             if(_t != NULL) {
                 epd->headers = _t;
@@ -867,7 +868,7 @@ int network_be_read(se_ptr_t *ptr)
                 return 0;
             }
 
-            epd->buf_size += 4096;
+            epd->buf_size += BUFFER_SIZE;
         }
 
         if(epd->status != STEP_READ) {

--- a/src/vhost.c
+++ b/src/vhost.c
@@ -10,6 +10,8 @@ int max_request_body = 0;
 int code_cache_ttl = 60; // set 0 to disable code cache
 int auto_reload_vhost_router = 0;
 char *temp_path = NULL;
+const char *lua_path = NULL;
+const char *lua_cpath = NULL;
 
 static void timeout_handle(void *ptr)
 {
@@ -140,6 +142,9 @@ int update_vhost_routes(char *f)
             update_timeout_ptr = add_timeout(NULL, auto_reload_vhost_router, timeout_handle);
         }
     }
+
+    lua_path = get_string_in_table(L, "lua-path", &tl);
+    lua_cpath = get_string_in_table(L, "lua-cpath", &tl);
 
     lua_pop(L, 1);
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -17,6 +17,9 @@ extern int ssl_epd_idx;
 
 extern logf_t *ACCESS_LOG;
 
+extern const char *lua_path;
+extern char process_chdir[924];
+
 static int exited = 0;
 static void on_exit_handler()
 {
@@ -422,7 +425,7 @@ int worker_process(epdata_t *epd, int thread_at)
     epd->vhost_root = get_vhost_root(epd->host, &epd->vhost_root_len);
 
     memcpy(buf_4096, epd->vhost_root, epd->vhost_root_len + 1);
-    sprintf(buf_4096 + epd->vhost_root_len + 1, "?.lua;%s/lua-libs/?.lua;", process_chdir);
+    sprintf(buf_4096 + epd->vhost_root_len + 1, "?.lua;%s/lua-libs/?.lua;%s", process_chdir, lua_path);
 
     lua_pushstring(L, buf_4096);
     lua_getglobal(L, "package");
@@ -443,7 +446,8 @@ int worker_process(epdata_t *epd, int thread_at)
 
     lua_routed = 0;
 
-    if(lua_resume(L, 1) == LUA_ERRRUN) {
+    if(lua_f_lua_uthread_resume_in_c(L, 1) == LUA_ERRRUN) {
+    //if(lua_resume(L, 1) == LUA_ERRRUN) {
         if(lua_isstring(L, -1)) {
             LOGF(ERR, "Lua:error %s", lua_tostring(L, -1));
             network_send_error(epd, 503, lua_tostring(L, -1));

--- a/src/worker.c
+++ b/src/worker.c
@@ -447,7 +447,6 @@ int worker_process(epdata_t *epd, int thread_at)
     lua_routed = 0;
 
     if(lua_f_lua_uthread_resume_in_c(L, 1) == LUA_ERRRUN) {
-    //if(lua_resume(L, 1) == LUA_ERRRUN) {
         if(lua_isstring(L, -1)) {
             LOGF(ERR, "Lua:error %s", lua_tostring(L, -1));
             network_send_error(epd, 503, lua_tostring(L, -1));


### PR DESCRIPTION
可以在host-route.lua中配置lua脚本搜索路径，方便组织网站的lua脚本目录。